### PR TITLE
Feature docker

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.15.1-alpine
+
+RUN apk update && apk upgrade && \
+    apk add --no-cache bash openssl
+
+COPY ./service /service
+COPY ./genkeys /genkeys
+
+WORKDIR /genkeys
+RUN chmod +x ./genkeys.sh
+
+ARG genkeys
+RUN if [ "$genkeys" = "true" ] ; then ./genkeys.sh; fi
+
+WORKDIR /service
+CMD ["go", "run", ".", "-conf", "./config.json"]

--- a/README.md
+++ b/README.md
@@ -163,6 +163,19 @@ go run -conf <seadistusfail>
 - Kui kasutad TARA-Mock-i instantsi, mis ei ole sinu kontrolli all, siis ära kasuta test-TARA klientrakenduse salasõna; sea salasõnaks muu väärtus; TARA-Mock ei kontrolli salasõna.
 - TARA-Mock-i CA sert usaldusankruks (s.t klientrakendus tuleb panna TARA-Mock-i usaldama).
 
+## Käivitamine kasutades Docker'it
+
+```
+docker-compose up
+```
+
+Vaikimisi eeldatakse, et võtmed ja serdid asuvad repo kaustas `service/vault`. Võtmeid ja serte saab eelnevalt genereerida käivitades käsud:  
+
+```
+docker-compose build --build-arg genkeys="true"
+docker-compose up
+```
+
 ## Klientrakenduse näidis
 
 TARA-Mock-ga kaasasolev klientrakenduse näidis pakub otspunkte:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.8"
+
+services:
+
+  tara-mock:
+    container_name: tara-mock
+    image: e-gov/tara-mock:latest
+    build:
+      context: .
+      args:
+        genkeys: "false"
+    ports:
+      - "0.0.0.0:8080:8080"


### PR DESCRIPTION
-Docker support
-Readme update
-.gitattributes -> *.sh text eol=lf  Needed if the project is cloned in Windows environment and started using docker-compose and genkeys="true"