### PR TITLE
Bugfix for fatal error: concurrent map read and map write

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/service/main.go
+++ b/service/main.go
@@ -37,7 +37,7 @@ type forTokenType struct {
 // Identsustõendite hoidla
 var idToendid = make(map[volituskood]forTokenType)
 
-var mutex = &sync.Mutex{}
+var mutex = &sync.RWMutex{}
 
 func main() {
 

--- a/service/sendToken.go
+++ b/service/sendToken.go
@@ -65,7 +65,10 @@ func sendIdentityToken(w http.ResponseWriter, r *http.Request) {
 
 	// Võta identsustõendile vajalikud andmed (v) mälus hoitavast
 	// identsustõendite andmete hoidlast.
+	mutex.RLock()
 	v, ok := idToendid[volituskood(m.Get("code"))]
+	mutex.RUnlock()
+
 	if !ok {
 		http.Error(w, "Identsustõendile vajalikke andmeid ei leia", 404)
 		return


### PR DESCRIPTION
"fatal error: concurrent map read and map write" exception occurs when under heavy load. Replaced Mutex with RWMutex and added read locks accordingly.