### PR TITLE
Bugfix  Issuer Identifier

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/service/helpers.go
+++ b/service/helpers.go
@@ -69,7 +69,7 @@ func sendConf(w http.ResponseWriter, r *http.Request) {
 	}
 
 	conf := Conf{
-		Issuer:                           "https://" + conf.TaraMockHost,
+		Issuer:                           "https://" + conf.TaraMockHost + conf.HTTPServerPort,
 		ScopesSupported:                  []string{"openid", "idcard", "mid", "banklink", "smartid", "eidas", "eidasonly", "email"},
 		ResponseTypesSupported:           []string{"code"},
 		SubjectTypesSupported:            []string{"public", "pairwise"},


### PR DESCRIPTION
OpenID Connect supports multiple Issuers per Host and Port combination. The issuer returned by discovery must exactly match the value of iss in the ID Token
https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier
https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation