### PR TITLE
AUT-567 Allow pulling Docker images and Alpine packages from alternate location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# IDEs and editors
+/.idea
+*.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 ARG DOCKERHUB_MIRROR
 FROM ${DOCKERHUB_MIRROR}library/golang:1.15.1-alpine
 
+ARG ALPINE_MIRROR
+RUN if [ -n "${ALPINE_MIRROR}" ]; then \
+    echo "${ALPINE_MIRROR}v3.12/main/" > /etc/apk/repositories && \
+    echo "${ALPINE_MIRROR}v3.12/community/" >> /etc/apk/repositories; fi
+
 RUN apk update && apk upgrade && \
     apk add --no-cache bash openssl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.15.1-alpine
+ARG DOCKERHUB_MIRROR
+FROM ${DOCKERHUB_MIRROR}library/golang:1.15.1-alpine
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash openssl


### PR DESCRIPTION
When building Docker image inside RIA infrastructure, external network connections are not allowed. Threrefore internal Docker Hub cache and internal Alpine package cache must be used, for example:
`docker build --build-arg DOCKERHUB_MIRROR=docker-hub-mirror.example.com/ --build-arg ALPINE_MIRROR=https://alpine-mirror.example.com/ .`

These arguments are optional, if omitted then default public Docker Hub and default public Alpine package repository are used, for example:
`docker build  .`