### PR TITLE
Base href support

### DIFF
--- a/service/authenticateUser.go
+++ b/service/authenticateUser.go
@@ -65,8 +65,8 @@ func authenticateUser(w http.ResponseWriter, r *http.Request) {
 		}
 
 		log.WithFields(log.Fields{
-			"sub":        forToken.sub,
-			"givenName":  forToken.givenName,
+			"sub": forToken.sub,
+			"givenName": forToken.givenName,
 			"familyName": forToken.familyName,
 		}).Debug("--- Automaatautentimine")
 

--- a/service/authenticateUser.go
+++ b/service/authenticateUser.go
@@ -65,8 +65,8 @@ func authenticateUser(w http.ResponseWriter, r *http.Request) {
 		}
 
 		log.WithFields(log.Fields{
-			"sub": forToken.sub,
-			"givenName": forToken.givenName,
+			"sub":        forToken.sub,
+			"givenName":  forToken.givenName,
 			"familyName": forToken.familyName,
 		}).Debug("--- Automaatautentimine")
 
@@ -112,10 +112,12 @@ func authenticateUser(w http.ResponseWriter, r *http.Request) {
 	type templateParams struct {
 		Request    OidcParams
 		Identities []Identity
+		BaseHref   string
 	}
 	mp := templateParams{
 		Request:    pr,
 		Identities: identities,
+		BaseHref:   conf.BaseHref,
 	}
 
 	// Loe mall, täida parameetritega ja saada leht sirvikusse.

--- a/service/config.go
+++ b/service/config.go
@@ -10,6 +10,7 @@ import (
 type Config struct {
 	TaraMockHost   string `json:"taraMockHost"`
 	HTTPServerPort string `json:"httpServerPort"`
+	BaseHref       string `json:"baseHref"`
 	// TARA-Mock-i HTTPS sert
 	TaraMockCert string `json:"taraMockCert"`
 	// TARA-Mock-i HTTPS privaatvõti
@@ -24,7 +25,7 @@ type Config struct {
 	IdentitiesFile       string `json:"identitiesFile"`
 	AuthenticateUserTmpl string `json:"authenticateUserTmpl"`
 	IndexTmpl            string `json:"indexTmpl"`
-	LogLevel            string `json:"logLevel"`
+	LogLevel             string `json:"logLevel"`
 }
 
 // TARA-Mock sisseloetud seadistus.

--- a/service/config.json
+++ b/service/config.json
@@ -1,6 +1,7 @@
 {
 	"taraMockHost": "localhost",
 	"httpServerPort": ":8080",
+	"baseHref": "/",
 	"taraMockCert": "vault/https.crt",
 	"taraMockKey": "vault/https.key",
 	"idTokenPrivKeyPath": "vault/idtoken.key",

--- a/service/helpers.go
+++ b/service/helpers.go
@@ -38,13 +38,21 @@ func getPtr(p string, r *http.Request) string {
 func landingPage(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Content-Type", "text/html")
 
+	type templateParams struct {
+		BaseHref string
+	}
+
+	mp := templateParams{
+		BaseHref: conf.BaseHref,
+	}
+
 	// Loe avalehe mall, täida ja saada sirvikusse.
 	t, err := template.ParseFiles(conf.IndexTmpl)
 	if err != nil {
 		log.WithError(err).Error("Unable to load template!")
 		return
 	}
-	t.Execute(w, nil)
+	t.Execute(w, mp)
 }
 
 // sendConf saadab OpenID Connect seadistuse (otspunkt

--- a/service/templates/authenticateUser.html
+++ b/service/templates/authenticateUser.html
@@ -5,6 +5,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>TARA-Mock</title>
+    <base href="{{ .BaseHref }}" target="_blank">
+
 
     <!-- JQuery -->
     <script src="https://code.jquery.com/jquery.min.js"></script>
@@ -12,7 +14,7 @@
     <!-- Material Design icons -->
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
-    <link rel="stylesheet" type="text/css" href="/static/styles.css" />
+    <link rel="stylesheet" type="text/css" href="static/styles.css" />
 
   </head>
 
@@ -38,7 +40,7 @@
     </div>
     <div class="Isikuvalikuala">
       <div class="paan">
-        <form action="/back" method="POST">
+        <form action="back" method="POST">
           <!-- Identiteedid (isikud), radio button rühmana -->
           <!-- 
             checked pannakse igale, kehtima jääb viimane.

--- a/service/templates/authenticateUser.html
+++ b/service/templates/authenticateUser.html
@@ -74,7 +74,7 @@
         või
       </div>
       <div class="paan">
-        <form action="/back" method="POST">
+        <form action="back" method="POST">
           <!-- Turvaelemendid, peidetud väljadena -->
           <input type="hidden" id="client_id" name="client_id"
             value="{{ .Request.ClientID }}">

--- a/service/templates/index.html
+++ b/service/templates/index.html
@@ -5,8 +5,9 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>TARA-Mock</title>
+    <base href="{{ .BaseHref }}" target="_blank">
 
-    <link rel="stylesheet" type="text/css" href="/static/styles.css" />
+    <link rel="stylesheet" type="text/css" href="static/styles.css" />
 
   </head>
 


### PR DESCRIPTION
Added a base href support. Useful, when TARA-Mock is not deployed to a root path, but extra path is between.

For example: https://my-test-server/tara-mock/oidc

Default base href is "/".