### PR TITLE
OpenID Provider Discovery url ${issuer}/.well-known/openid-configuration

### DIFF
--- a/service/main.go
+++ b/service/main.go
@@ -62,6 +62,7 @@ func main() {
 	// Go-s "/" käsitleb ka need teed, millele oma käsitlejat ei leidu.
 	http.HandleFunc("/", landingPage)
 	http.HandleFunc("/health", healthCheck)
+	http.HandleFunc("/.well-known/openid-configuration", sendConf)
 	http.HandleFunc("/oidc/.well-known/openid-configuration", sendConf)
 	http.HandleFunc("/oidc/authorize", authenticateUser)
 	http.HandleFunc("/back", sendUserBack)


### PR DESCRIPTION
OpenID Providers supporting Discovery must make a JSON document available at the path formed by concatenating the string /.well-known/openid-configuration to the Issuer.